### PR TITLE
Ignore unknown entity type

### DIFF
--- a/lib/draftjs_exporter/entity_state.rb
+++ b/lib/draftjs_exporter/entity_state.rb
@@ -8,6 +8,8 @@ module DraftjsExporter
   class EntityState
     attr_reader :entity_decorators, :entity_map, :entity_stack, :root_element
 
+    DEFAULT_ENTITY_DECORATOR = Entities::Null.new
+
     def initialize(root_element, entity_decorators, entity_map)
       @entity_decorators = entity_decorators
       @entity_map = entity_map
@@ -33,7 +35,7 @@ module DraftjsExporter
     def start_command(command)
       entity_details = entity_for(command.data)
 
-      decorator = entity_decorators.fetch(entity_details.fetch(:type))
+      decorator = entity_decorators.fetch(entity_details.fetch(:type), DEFAULT_ENTITY_DECORATOR)
       parent_element = entity_stack.last.first
       new_element = decorator.call(parent_element, entity_details)
       entity_stack.push([new_element, entity_details])

--- a/spec/integrations/html_spec.rb
+++ b/spec/integrations/html_spec.rb
@@ -124,6 +124,38 @@ RSpec.describe DraftjsExporter::HTML do
         expect(mapper.call(input)).to eq(expected_output)
       end
 
+      it 'ignore unkown entity type' do
+        input = {
+          entityMap: {
+            '0' => {
+              type: 'UNKNOWN_TYPE',
+            }
+          },
+          blocks: [
+            {
+              key: 'dem5p',
+              text: 'some paragraph text',
+              type: 'unstyled',
+              depth: 0,
+              inlineStyleRanges: [],
+              entityRanges: [
+                {
+                  offset: 5,
+                  length: 9,
+                  key: 0
+                }
+              ]
+            }
+          ]
+        }
+
+        expected_output = <<-OUTPUT.strip
+<div>some paragraph text</div>
+        OUTPUT
+
+        expect(mapper.call(input)).to eq(expected_output)
+      end
+
       context 'with deeply_symbolized entities' do
         it 'decodes the content_state to html' do
           input = {


### PR DESCRIPTION
This commit may prevent `KeyError` exception (`key not found: XXX`) on unexpected entity types which is useful when you have no control on draftjs content.