### PR TITLE
Add an ability to pass options to Nokogiri when rendering

### DIFF
--- a/lib/draftjs_exporter/html.rb
+++ b/lib/draftjs_exporter/html.rb
@@ -15,14 +15,14 @@ module DraftjsExporter
       @entity_decorators = entity_decorators
     end
 
-    def call(content_state)
+    def call(content_state, options = {})
       wrapper_state = WrapperState.new(block_map)
       content_state.fetch(:blocks, []).each do |block|
         element = wrapper_state.element_for(block)
         entity_map = content_state.fetch(:entityMap, {})
         block_contents(element, block, entity_map)
       end
-      wrapper_state.to_s
+      wrapper_state.to_html(options)
     end
 
     private

--- a/lib/draftjs_exporter/wrapper_state.rb
+++ b/lib/draftjs_exporter/wrapper_state.rb
@@ -15,7 +15,11 @@ module DraftjsExporter
     end
 
     def to_s
-      fragment.to_s
+      to_html
+    end
+
+    def to_html(options = {})
+      fragment.to_html(options)
     end
 
     private

--- a/spec/integrations/html_spec.rb
+++ b/spec/integrations/html_spec.rb
@@ -239,5 +239,39 @@ RSpec.describe DraftjsExporter::HTML do
         expect(mapper.call(input)).to eq(expected_output)
       end
     end
+
+    context 'with UTF-8 encoding' do
+      it 'leaves non-latin letters as-is' do
+        input = {
+          entityMap: {},
+          blocks: [
+            {
+              key: 'ckf8d',
+              text: 'Russian: Привет, мир!',
+              type: 'unordered-list-item',
+              depth: 0,
+              inlineStyleRanges: [],
+              entityRanges: [],
+              data: {}
+            },
+            {
+              key: 'fi809',
+              text: 'Japanese: 曖昧さ回避',
+              type: 'unordered-list-item',
+              depth: 0,
+              inlineStyleRanges: [],
+              entityRanges: [],
+              data: {}
+            }
+          ]
+        }
+
+        expected_output = <<-OUTPUT.strip
+          <ul class=\"public-DraftStyleDefault-ul\">\n<li>Russian: Привет, мир!</li>\n<li>Japanese: 曖昧さ回避</li>\n</ul>
+        OUTPUT
+
+        expect(mapper.call(input, encoding: 'UTF-8')).to eq(expected_output)
+      end
+    end
   end
 end


### PR DESCRIPTION
When converting DraftJS content state to HTML using `draftjs_exporter`, any non-latin letters are rendered as HTML entities. Consider the following example: (I omitted config for brevity):

``` ruby
config = # ...

content = {
  "entityMap": {},
  "blocks": [
    {
      "key": "ckf8d",
      "text": "Russian: Привет, мир!",
      "type": "unordered-list-item",
      "depth": 0,
      "inlineStyleRanges": [],
      "entityRanges": [],
      "data": {}
    },
    {
      "key": "fi809",
      "text": "Japanese: 曖昧さ回避",
      "type": "unordered-list-item",
      "depth": 0,
      "inlineStyleRanges": [],
      "entityRanges": [],
      "data": {}
    }
  ]
}

exporter = DraftjsExporter::HTML.new(config)
exporter.call(content)
```

This will yield 

```
<ul class=\"unordered-list\">\n<li>Russian: &#1055;&#1088;&#1080;&#1074;&#1077;&#1090;, &#1084;&#1080;&#1088;!</li>\n<li>Japanese: &#26326;&#26151;&#12373;&#22238;&#36991;</li>\n</ul>
```

Though most web browsers will display this HTML without any problem (I think), this can be inconvenient in many ways, so this PR features an ability to pass additional options to Nokigiri XML renderer (you can view the whole list [here](http://www.rubydoc.info/github/sparklemotion/nokogiri/Nokogiri%2FXML%2FNode:write_to)) as the second (optional) parameter of `DraftjsExporter::HTML.call`, so it should not break backward compatibility. 

Returning to my example, if I pass `encoding: 'UTF-8'` when rendering, this will yield the desired result:

``` ruby
exporter.call(content, encoding: 'UTF-8') #=> "<ul class=\"unordered-list\">\n<li>Russian: Привет, мир!</li>\n<li>Japanese: 曖昧さ回避</li>\n</ul>"
```