### PR TITLE
Adds ability to ignore unknown styles

### DIFF
--- a/lib/draftjs_exporter/html.rb
+++ b/lib/draftjs_exporter/html.rb
@@ -9,10 +9,11 @@ module DraftjsExporter
   class HTML
     attr_reader :block_map, :style_map, :entity_decorators
 
-    def initialize(block_map:, style_map:, entity_decorators:)
+    def initialize(block_map:, style_map:, entity_decorators:, style_options: {})
       @block_map = block_map
       @style_map = style_map
       @entity_decorators = entity_decorators
+      @style_options = style_options
     end
 
     def call(content_state, options = {})
@@ -28,7 +29,7 @@ module DraftjsExporter
     private
 
     def block_contents(element, block, entity_map)
-      style_state = StyleState.new(style_map)
+      style_state = StyleState.new(style_map, **@style_options)
       entity_state = EntityState.new(element, entity_decorators, entity_map)
       build_command_groups(block).each do |text, commands|
         commands.each do |command|

--- a/lib/draftjs_exporter/version.rb
+++ b/lib/draftjs_exporter/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module DraftjsExporter
-  VERSION = '0.0.7'.freeze
+  VERSION = '0.1.0'.freeze
 end


### PR DESCRIPTION
Allows you to use a ```:style_options``` to configure the style processing.  The only current option is a ```:unknown_styles``` which can be ```:warn, :error, :ignore``` depending on what you want to do with styles you aren't handling in the conversion.  Default is ```:warn```